### PR TITLE
v1.3.3 Minor updates - Bugfixes in UI handling of settings' paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can use Burp's built-in browser to deploy PwnFox for Chromium. Here are the 
 ## Compiling the extension on your own with Maven
 ```
 git clone https://github.com/adeadfed/PwnFox-For-Chromium
-cd PwnFox-For-Chromium/burp
+cd PwnFox-For-Chromium/
 mvn clean compile assembly:single
 ls -l target/PwnFox-For-Chromium*.jar
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ You can use Burp's built-in browser to deploy PwnFox for Chromium. Here are the 
 /Applications/Burp Suite Community Professional.app/Contents/Resources/app/burpbrowser/{VERSION}/Chromium.app/Contents/MacOS/Chromium
 ```
 
-## Compiling the extension on your own with Maven
+## Building from Sources
+> This project depends on the IntelliJ GUI Designer. Make sure you have the latest [Swing UI Designer](https://plugins.jetbrains.com/plugin/25304-swing-ui-designer) plugin installed if you would like to edit the GUI layout. 
+
 ```
 git clone https://github.com/adeadfed/PwnFox-For-Chromium
 cd PwnFox-For-Chromium/
@@ -67,12 +69,3 @@ You can edit Chromium proxy configuration and enable/disable it using the built-
 - All extension settings can be managed in BurpSuite directly
 - Additional options for proxy configuration in the bundled Chromium extensions
 - You can keep unique Chromium data for each engagement by separating the Chromium profile data directories
-
-## Building
-This project depends on the IntelliJ GUI Designer. Make sure you have the latest [Swing UI Designer](https://plugins.jetbrains.com/plugin/25304-swing-ui-designer) plugin installed. 
-
-To build it yourself using Maven: 
-
-1. Ensure IntelliJ is set to "Generate GUI into: Java source code on compilation" (Settings > Editor > GUI Designer).
-2. Run `mvn clean install`.
-3. Load `target/PwnFox-For-Chromium-1.3.2-jar-with-dependencies.jar` into Burp.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,12 @@ You can edit Chromium proxy configuration and enable/disable it using the built-
 - All extension settings can be managed in BurpSuite directly
 - Additional options for proxy configuration in the bundled Chromium extensions
 - You can keep unique Chromium data for each engagement by separating the Chromium profile data directories
+
+## Building
+This project depends on the IntelliJ GUI Designer. Make sure you have the latest [Swing UI Designer](https://plugins.jetbrains.com/plugin/25304-swing-ui-designer) plugin installed. 
+
+To build it yourself using Maven: 
+
+1. Ensure IntelliJ is set to "Generate GUI into: Java source code on compilation" (Settings > Editor > GUI Designer).
+2. Run `mvn clean install`.
+3. Load `target/PwnFox-For-Chromium-1.3.2-jar-with-dependencies.jar` into Burp.

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,6 @@
         </dependency>
         <dependency>
             <groupId>com.intellij</groupId>
-            <artifactId>javac2</artifactId>
-            <version>7.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.intellij</groupId>
             <artifactId>forms_rt</artifactId>
             <version>7.0.3</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.adeadfed</groupId>
     <artifactId>PwnFox-For-Chromium</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
 
     <properties>
         <maven.compiler.release>21</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.adeadfed</groupId>
     <artifactId>PwnFox-For-Chromium</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
     <version>1.3.2</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -44,29 +43,20 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>ideauidesigner-maven-plugin</artifactId>
-                <version>1.0-beta-1</version>
+                <version>3.6.0</version> <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <appendAssemblyId>true</appendAssemblyId>
+            </configuration>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>javac2</goal>
-                        </goals>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <goals>
+                        <goal>single</goal>
+                    </goals>
                     </execution>
                 </executions>
-
-                <configuration>
-                    <fork>true</fork>
-                    <debug>true</debug>
-                    <failOnError>true</failOnError>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -43,18 +43,20 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.8.0</version> <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-                <appendAssemblyId>true</appendAssemblyId>
-            </configuration>
+                <version>3.8.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>true</appendAssemblyId>
+                </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> <goals>
-                        <goal>single</goal>
-                    </goals>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version> <configuration>
+                <version>3.8.0</version> <configuration>
                 <descriptorRefs>
                     <descriptorRef>jar-with-dependencies</descriptorRef>
                 </descriptorRefs>

--- a/src/main/java/com/adeadfed/PwnFoxForChromiumUI.java
+++ b/src/main/java/com/adeadfed/PwnFoxForChromiumUI.java
@@ -37,6 +37,10 @@ public class PwnFoxForChromiumUI {
     private JButton orangeButton;
     private JButton pinkButton;
     private JButton magentaButton;
+    private JButton[] profileButtons = {
+        blueButton, cyanButton, greenButton, yellowButton,
+        redButton, orangeButton, pinkButton, magentaButton
+    };
     private JLabel helpLabel;
     private JButton resetProfileNamesButton;
     private JButton locateBurpBrowserButton;
@@ -65,11 +69,6 @@ public class PwnFoxForChromiumUI {
     private void setupResetProfileNamesButton() {
         Runnable resetProfileNamesCallback = () -> {
             try {
-                JButton[] profileButtons = {
-                        blueButton, cyanButton, greenButton, yellowButton,
-                        redButton, orangeButton, pinkButton, magentaButton
-                };
-
                 for (JButton b: profileButtons) {
                     String defaultColorValue = b.getName();
                     b.setText(defaultColorValue);
@@ -104,11 +103,6 @@ public class PwnFoxForChromiumUI {
     }
 
     private void setupProfileButtons() {
-        JButton[] profileButtons = {
-                blueButton, cyanButton, greenButton, yellowButton,
-                redButton, orangeButton, pinkButton, magentaButton
-        };
-
         ActionListener buttonPressedListener = e -> {
             JButton button = (JButton) e.getSource();
             if (isRenameKeyPressed(e)) {

--- a/src/main/java/com/adeadfed/PwnFoxForChromiumUI.java
+++ b/src/main/java/com/adeadfed/PwnFoxForChromiumUI.java
@@ -62,13 +62,12 @@ public class PwnFoxForChromiumUI {
         
         Runnable saveTextFieldCallback = () -> {
             if (uiPath.isValid()) {
-                String path = uiPath.getText();
-                pwnChromiumExtension.pwnChromiumPreferences.set(preference, path);
+                pwnChromiumExtension.pwnChromiumPreferences.set(preference, uiPath.getText());
             }
         };
 
         uiPath.setInputVerifier(uiPathInputVerifier);
-        
+
         uiPath.addActionListener(e -> saveTextFieldCallback.run());
         button.addActionListener(e -> uiChoosePath(preference, uiPath, pathMode));
     }

--- a/src/main/java/com/adeadfed/PwnFoxForChromiumUI.java
+++ b/src/main/java/com/adeadfed/PwnFoxForChromiumUI.java
@@ -37,10 +37,6 @@ public class PwnFoxForChromiumUI {
     private JButton orangeButton;
     private JButton pinkButton;
     private JButton magentaButton;
-    private JButton[] profileButtons = {
-        blueButton, cyanButton, greenButton, yellowButton,
-        redButton, orangeButton, pinkButton, magentaButton
-    };
     private JLabel helpLabel;
     private JButton resetProfileNamesButton;
     private JButton locateBurpBrowserButton;
@@ -58,17 +54,33 @@ public class PwnFoxForChromiumUI {
         helpLabel.setText(modifierKey + " + Click to edit button names");
     }
 
-    private void setupPreferenceButton(Preference preference, JButton button, JTextField uiPath, int pathMode) {
-        String path = pwnChromiumExtension.pwnChromiumPreferences.get(preference);
-        if (path != null) {
-            uiPath.setText(path);
+    private void setupUiPathField(Preference preference, JButton button, JTextField uiPath, InputVerifier uiPathInputVerifier, int pathMode) {
+        String savedPath = pwnChromiumExtension.pwnChromiumPreferences.get(preference);
+        if (savedPath != null) {
+            uiPath.setText(savedPath);
         }
+        
+        Runnable saveTextFieldCallback = () -> {
+            if (uiPath.isValid()) {
+                String path = uiPath.getText();
+                pwnChromiumExtension.pwnChromiumPreferences.set(preference, path);
+            }
+        };
+
+        uiPath.setInputVerifier(uiPathInputVerifier);
+        
+        uiPath.addActionListener(e -> saveTextFieldCallback.run());
         button.addActionListener(e -> uiChoosePath(preference, uiPath, pathMode));
     }
 
     private void setupResetProfileNamesButton() {
         Runnable resetProfileNamesCallback = () -> {
             try {
+                JButton[] profileButtons = {
+                    blueButton, cyanButton, greenButton, yellowButton,
+                    redButton, orangeButton, pinkButton, magentaButton
+                };
+
                 for (JButton b: profileButtons) {
                     String defaultColorValue = b.getName();
                     b.setText(defaultColorValue);
@@ -85,15 +97,15 @@ public class PwnFoxForChromiumUI {
     private void setupLocateBurpBrowserButton() {
         Runnable locateBurpBrowserCallback = () -> {
             try {
-                String burpBrowserPath = pwnChromiumExtension.pwnChromiumPreferences.browserPath.getDefault();
-                if (burpBrowserPath == null) {
+                String path = pwnChromiumExtension.pwnChromiumPreferences.browserPath.getDefault();
+                if (path == null) {
                     throw new Exception("Failed to locate BurpBrowser automatically.");
                 }
                 pwnChromiumExtension.pwnChromiumPreferences.set(
                     pwnChromiumExtension.pwnChromiumPreferences.browserPath,
-                    burpBrowserPath
+                    path
                 );
-                pwnChromeExePath.setText(burpBrowserPath);
+                pwnChromeExePath.setText(path);
             } catch (Exception e) {
                 JOptionPane.showMessageDialog(null, "An error locating BurpBrowser occured. Check the extension logs");
                 pwnChromiumExtension.montoyaApi.logging().logToError(e);
@@ -103,6 +115,11 @@ public class PwnFoxForChromiumUI {
     }
 
     private void setupProfileButtons() {
+        JButton[] profileButtons = {
+            blueButton, cyanButton, greenButton, yellowButton,
+            redButton, orangeButton, pinkButton, magentaButton
+        };
+
         ActionListener buttonPressedListener = e -> {
             JButton button = (JButton) e.getSource();
             if (isRenameKeyPressed(e)) {
@@ -195,20 +212,19 @@ public class PwnFoxForChromiumUI {
     public PwnFoxForChromiumUI(PwnFoxForChromium pwnChromiumExtension) {
         setPwnChromiumExtension(pwnChromiumExtension);
 
-        pwnChromeExePath.setInputVerifier(new TextFieldVerifier(FsValidator::isChromiumExecutableValid));
-        pwnChromeProfilesPath.setInputVerifier(new TextFieldVerifier(FsValidator::isDirValid));
-       
-        setupPreferenceButton(
+        setupUiPathField(
             pwnChromiumExtension.pwnChromiumPreferences.browserPath,
             chooseExeButton,
             pwnChromeExePath, 
+            new TextFieldVerifier(FsValidator::isChromiumExecutableValid),
             JFileChooser.FILES_ONLY
         );
 
-        setupPreferenceButton(
+        setupUiPathField(
             pwnChromiumExtension.pwnChromiumPreferences.profilesDir,
             chooseProfilesDirButton,
             pwnChromeProfilesPath,
+            new TextFieldVerifier(FsValidator::isDirValid),
             JFileChooser.DIRECTORIES_ONLY
         );
 

--- a/src/main/java/com/adeadfed/validators/FsValidator.java
+++ b/src/main/java/com/adeadfed/validators/FsValidator.java
@@ -8,13 +8,13 @@ import java.nio.file.Paths;
 
 public class FsValidator {
     public static boolean isDirValid(String directory) {
-        return Files.isDirectory(Paths.get(directory));
+        return directory.length() != 0 && Files.isDirectory(Paths.get(directory));
     }
 
     public static boolean isChromiumExecutableValid(String pwnChromeExePath) {
         // check if executable is named Chrome or Chromium
         String chromeExeName = Paths.get(pwnChromeExePath).getFileName().toString().toLowerCase();
-        if (!(chromeExeName.contains("chrom"))) {
+        if (!chromeExeName.contains("chrom")) {
             return false;
         }
         // check if the --version flag of the chromium executable returns Chrome or Chromium in the output


### PR DESCRIPTION
- Closes https://github.com/adeadfed/PwnFox-For-Chromium/issues/11
- Closes the bug from Discord - paths not saved after editing the textfield directly
- Reverts back to the local array of buttons in 2 functions iterating over them - this used to break the code during init
- Updates to `Pom.xml` -- removed unused dependencies. The Jar is now 700 KB instead of 2MB. The build command is the same, `mvn clean compile assembly:single`